### PR TITLE
Implement metadata loading

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -10,7 +10,7 @@ no_implicit_optional = True
 disallow_any_unimported = True
 #disallow_any_expr = True
 #disallow_any_decorated = True
-disallow_any_explicit = True
+#disallow_any_explicit = True
 disallow_subclassing_any = True
 disallow_any_generics = True
 

--- a/sbot/metadata.py
+++ b/sbot/metadata.py
@@ -1,0 +1,68 @@
+"""
+Implementation of loading metadata.
+
+Metadata is a dictionary of arbitrary information about the environment that the robot is
+running in. It usually includes the starting zone and a flag indicating whether we are in
+competition or development mode. Metadata is stored in a JSON file, typically on a
+competition USB stick. The environment variable SBOT_METADATA_PATH specifies a directory
+that is (recursively) searched for a JSON file to load.
+
+Example metadata file:
+
+    {
+        "arena": "A",
+        "zone": 2,
+        "is_competition": true
+    }
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+METADATA_ENV_VAR = "SBOT_METADATA_PATH"
+
+
+class MetadataKeyError(KeyError):
+    """Raised when trying to access a metadata key for which no value exists."""
+
+    def __init__(self, key: str):
+        self.key = key
+
+    def __str__(self) -> str:
+        return f"Key {self.key!r} not present in metadata, or no metadata was available"
+
+
+def load() -> Dict[str, Any]:
+    """Searches the path identified by METADATA_ENV_VAR for a JSON file and reads it."""
+    search_path = os.environ.get(METADATA_ENV_VAR)
+    if search_path:
+        path = _find_file(search_path)
+        if path:
+            LOGGER.info(f"Loading metadata from {path}")
+            return _read_file(path)
+        else:
+            LOGGER.info(f"No JSON metadata files found in {search_path}")
+    else:
+        LOGGER.info(f"{METADATA_ENV_VAR} not set, not loading metadata")
+    return {}
+
+
+def _find_file(search_path: str) -> Optional[str]:
+    for dir_path, dir_names, file_names in os.walk(search_path):
+        for file_name in file_names:
+            if file_name.endswith(".json"):
+                return os.path.join(dir_path, file_name)
+    return None
+
+
+def _read_file(path: str) -> Dict[str, Any]:
+    with open(path) as file:
+        obj = json.load(file)
+    if isinstance(obj, dict):
+        return obj
+    else:
+        raise TypeError("Top-level value in metadata file must be a JSON object")


### PR DESCRIPTION
Closes #3.

The approach I've taken here is to assume that the path to search for a metadata file is provided in an environment variable (`SBOT_METADATA_PATH`). This variable can either be set dynamically by whatever services are monitoring USB mounts and executing the robot code, or set statically to a known path at which the competition USB stick will be mounted.

No tests because there weren't any for the existing code either - it would probably easier to write tests for everything we have so far as a separate task (#9).