### PR TITLE
Fix match duration

### DIFF
--- a/sbot/robot.py
+++ b/sbot/robot.py
@@ -37,7 +37,7 @@ __version__ = "0.5.1"
 
 LOGGER = logging.getLogger(__name__)
 
-GAME_LENGTH = 180
+GAME_LENGTH = 120
 
 T = TypeVar("T", bound=Board)
 


### PR DESCRIPTION
For "Scavengers" deployed at Smallpeice 2019, the game duration
should be 120 seconds, not 180. This can be verified against the [rules](https://sbot.readthedocs.io/en/latest/rules.html).

We should *really* not be hardcoding this in the package.