### PR TITLE
Support multiple auxilliary boards

### DIFF
--- a/sbot/robot.py
+++ b/sbot/robot.py
@@ -86,23 +86,13 @@ class Robot(BaseRobot):
         self._motor_boards = BoardGroup[MotorBoard](
             HardwareEnvironment.get_backend(MotorBoard),
         )
-        self.motor_board: Optional[MotorBoard] = (
-            self._get_optional_board(self._motor_boards)
-        )
 
         self._servo_boards = BoardGroup[ServoBoard](
             HardwareEnvironment.get_backend(ServoBoard),
         )
-        self.servo_board: Optional[ServoBoard] = (
-            self._get_optional_board(self._servo_boards)
-        )
 
         self._arduinos = BoardGroup[SBArduinoBoard](
             HardwareEnvironment.get_backend(SBArduinoBoard),
-        )
-
-        self.arduino: Optional[SBArduinoBoard] = (
-            self._get_optional_board(self._arduinos)
         )
 
         if ENABLE_VISION:
@@ -130,6 +120,33 @@ class Robot(BaseRobot):
         for board in Board.BOARDS:
             LOGGER.info(f"Found {board.name}, serial: {board.serial}")
             LOGGER.debug(f"Firmware Version of {board.serial}: {board.firmware_version}")
+
+    @property
+    def motor_board(self) -> MotorBoard:
+        """
+        Get the motor board.
+
+        A CommunicationError is raised if there isn't exactly one attached.
+        """
+        return self._motor_boards.singular()
+
+    @property
+    def servo_board(self) -> ServoBoard:
+        """
+        Get the servo board.
+
+        A CommunicationError is raised if there isn't exactly one attached.
+        """
+        return self._servo_boards.singular()
+
+    @property
+    def arduino(self) -> SBArduinoBoard:
+        """
+        Get the arduino.
+
+        A CommunicationError is raised if there isn't exactly one attached.
+        """
+        return self._arduinos.singular()
 
     @property
     def camera(self) -> Optional[MarkerCamera]:

--- a/sbot/robot.py
+++ b/sbot/robot.py
@@ -83,15 +83,15 @@ class Robot(BaseRobot):
         self.power_board.outputs.power_on()
 
     def _init_auxilliary_boards(self) -> None:
-        self._motor_boards = BoardGroup[MotorBoard](
+        self.motor_boards = BoardGroup[MotorBoard](
             HardwareEnvironment.get_backend(MotorBoard),
         )
 
-        self._servo_boards = BoardGroup[ServoBoard](
+        self.servo_boards = BoardGroup[ServoBoard](
             HardwareEnvironment.get_backend(ServoBoard),
         )
 
-        self._arduinos = BoardGroup[SBArduinoBoard](
+        self.arduinos = BoardGroup[SBArduinoBoard](
             HardwareEnvironment.get_backend(SBArduinoBoard),
         )
 
@@ -128,7 +128,7 @@ class Robot(BaseRobot):
 
         A CommunicationError is raised if there isn't exactly one attached.
         """
-        return self._motor_boards.singular()
+        return self.motor_boards.singular()
 
     @property
     def servo_board(self) -> ServoBoard:
@@ -137,7 +137,7 @@ class Robot(BaseRobot):
 
         A CommunicationError is raised if there isn't exactly one attached.
         """
-        return self._servo_boards.singular()
+        return self.servo_boards.singular()
 
     @property
     def arduino(self) -> SBArduinoBoard:
@@ -146,7 +146,7 @@ class Robot(BaseRobot):
 
         A CommunicationError is raised if there isn't exactly one attached.
         """
-        return self._arduinos.singular()
+        return self.arduinos.singular()
 
     @property
     def camera(self) -> Optional[MarkerCamera]:


### PR DESCRIPTION
This change the semantics of `r.motor_board`, `r.servo_board` and `r.arduino` so that an exception about there being the wrong number of boards connected is only raised on attribute access rather than during the initialisation of the `Robot` object.

This allows you to use multiple boards, so long as only access them via `r.*_boards` and now `r.*_board`.

We thought this needed to be shipped for the 2019 summer school, but now it doesn't.