### PR TITLE
Changed r.power_board.wait_start() to r.wait_start()

### DIFF
--- a/docs/source/api/power-board.rst
+++ b/docs/source/api/power-board.rst
@@ -102,7 +102,7 @@ the start.
 
 .. code:: python
 
-   r.power_board.wait_start()
+   r.wait_start()
 
 This may be useful for debugging, but be sure to remove it in the
 competition, as you won't be allowed to touch the start button after a match has begun!


### PR DESCRIPTION
Changed r.power_board.wait_start() to r.wait_start() because r.power_board.wait_start() doesn't exist