### PR TITLE
Fix Sphinx Warnings

### DIFF
--- a/docs/source/api/arduino.rst
+++ b/docs/source/api/arduino.rst
@@ -98,8 +98,8 @@ have to be read differently. The arduino has six analogue inputs, which
 are labelled ``A0`` to ``A5``; however pins ``A4`` and ``A5`` are reserved and cannot be used.
 
 .. Hint:: Analogue signals can have any voltage, while digital
-signals can only take on one of two voltages. You can read more about
-digital vs analogue signals `here <https://learn.sparkfun.com/tutorials/analog-vs-digital>`__.
+   signals can only take on one of two voltages. You can read more about
+   digital vs analogue signals `here <https://learn.sparkfun.com/tutorials/analog-vs-digital>`__.
 
 .. code:: python
    

--- a/docs/source/tutorials/connecting-your-kit.rst
+++ b/docs/source/tutorials/connecting-your-kit.rst
@@ -110,7 +110,7 @@ how to connect things up. You'll be cutting your own wires here!
     CamCons onto the opposite ends of a pair of wires, ensuring that positive
     connects to positive and ground to ground, and then plugging one end into
     a low power socket on the side of the Power Board and the other into the 12V
-     socket on the servo board.
+    socket on the servo board.
 8.  Connect the Servo Board to the Pi by way of another micro-USB cable; the
     USB A (rectangle) end goes into any USB socket on the Pi or connected via 
     the USB hub, the micro-USB end goes into the Servo Board.

--- a/docs/source/tutorials/using-your-kit.rst
+++ b/docs/source/tutorials/using-your-kit.rst
@@ -142,7 +142,7 @@ Servos are a motor which knows what position it's at. You can tell it an angle
 and it'll handle turning to that value! 
 
 .. Warning:: Be warned, most servos can't turn a full 360 degrees!
-Always check how far it can move before you design a cool robot arm!
+   Always check how far it can move before you design a cool robot arm!
 
 Servos can be set to turn to a specific position. Sadly you can't just tell it
 an angle to turn to in degrees, you can only tell it to go between ``-1`` and 


### PR DESCRIPTION
Warnings were:

```
/home/dan/Code/sro/sbot/docs/source/api/arduino.rst:98: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/dan/Code/sro/sbot/docs/source/tutorials/connecting-your-kit.rst:112: WARNING: Unexpected indentation.
/home/dan/Code/sro/sbot/docs/source/tutorials/using-your-kit.rst:144: WARNING: Explicit markup ends without a blank line; unexpected unindent.
```