### PR TITLE
Build docs in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,10 @@ jobs:
       - run: make lint
       - run: make type
       - run: make test
+      - run: make -C docs html
+      - store_artifacts:
+          path: docs/build/html/
+          destination: docs
       - save_cache:
           paths:
             - /root/.cache/pypoetry/virtualenvs


### PR DESCRIPTION
This allows us to check that the docs actually build, as well as preview them per branch and version without adding branches to ReadTheDocs.