### PR TITLE
Improve timeout handling

### DIFF
--- a/sbot/timeout.py
+++ b/sbot/timeout.py
@@ -1,28 +1,20 @@
 """Functions for killing the robot after a certain amount of time."""
+import _thread
 import logging
-import signal
-import sys
-from types import FrameType
+from threading import Timer
 
 logger = logging.getLogger(__name__)
 
-# TODO make this work on Windows
 
-
-def timeout_handler(signal_type: signal.Signals, stack_frame: FrameType) -> None:
+def timeout_handler() -> None:
     """
-    Handle the `SIGALRM` to kill the current process.
+    Handle the timeout to kill the current process.
 
     This function is called when the timeout expires and will stop the robot's main process.
     In order for this to work, any threads that are created must be daemons.
-
-    NOTE: This function is not called on Windows.
-
-    :param signal_type: The sginal that triggered this handler
-    :param stack_frame: The stack frame at the time of the signal
-    :raises SystemExit: To stop the robot's execution after the timeout
     """
-    raise SystemExit("Timeout expired: Game Over!")
+    logger.info("Timeout expired: Game Over!")
+    _thread.interrupt_main()
 
 
 def kill_after_delay(timeout_seconds: int) -> None:
@@ -31,16 +23,8 @@ def kill_after_delay(timeout_seconds: int) -> None:
 
     Interrupts main process after the given delay.
 
-    NOTE: This functionality does not work on Windows,
-    so the robot will not stop after the timeout.
-
     :param timeout_seconds: The number of seconds to wait before killing the robot
     """
-    if sys.platform == "win32":
-        logger.warning(
-            "Game timeout is not supported on Windows. "
-            "The code will not stop after the timeout.")
-    else:
-        logger.debug(f"Kill Signal Timeout set: {timeout_seconds}s")
-        signal.signal(signal.SIGALRM, timeout_handler)  # type: ignore
-        signal.alarm(timeout_seconds)
+    timer = Timer(timeout_seconds, timeout_handler)
+    logger.debug(f"Kill Signal Timeout set: {timeout_seconds}s")
+    timer.start()

--- a/sbot/timeout.py
+++ b/sbot/timeout.py
@@ -1,6 +1,7 @@
 """Functions for killing the robot after a certain amount of time."""
-import _thread
 import logging
+import os
+import signal
 from threading import Timer
 
 logger = logging.getLogger(__name__)
@@ -14,7 +15,7 @@ def timeout_handler() -> None:
     In order for this to work, any threads that are created must be daemons.
     """
     logger.info("Timeout expired: Game Over!")
-    _thread.interrupt_main()
+    os.kill(os.getpid(), signal.SIGTERM)
 
 
 def kill_after_delay(timeout_seconds: int) -> None:

--- a/sbot/timeout.py
+++ b/sbot/timeout.py
@@ -1,30 +1,13 @@
 """Functions for killing the robot after a certain amount of time."""
 import logging
 import os
-import platform
 import signal
+import sys
 from threading import Timer
 from types import FrameType
 from typing import Optional
 
 logger = logging.getLogger(__name__)
-
-
-IS_LINUX = platform.system() == "Linux"
-
-# `SIGALRM` will only exist on Linux
-TERMINATING_SIGNAL = getattr(signal, "SIGALRM", signal.SIGTERM)
-
-
-def raise_signal(signum: int) -> None:
-    """
-    Sends a signal to the current process.
-
-    Similar to `signal.raise_signal`, however uses the main process's signal handler.
-
-    :param signum: The signal to raise
-    """
-    os.kill(os.getpid(), signum)
 
 
 def timeout_handler(signal_type: int, stack_frame: Optional[FrameType]) -> None:
@@ -33,9 +16,27 @@ def timeout_handler(signal_type: int, stack_frame: Optional[FrameType]) -> None:
 
     This function is called when the timeout expires and will stop the robot's main process.
     In order for this to work, any threads that are created must be daemons.
+
+    NOTE: This function is not called on Windows.
+
+    :param signal_type: The sginal that triggered this handler
+    :param stack_frame: The stack frame at the time of the signal
     """
-    print("Timeout expired: Game Over!")
+    logger.info("Timeout expired: Game Over!")
     exit(0)
+
+
+def win_timeout_handler() -> None:
+    """
+    Kill the main process on Windows.
+
+    This function is called when the timeout expires and will stop the robot's main process.
+    In order for this to work, any threads that are created must be daemons.
+
+    NOTE: This function is only called on Windows.
+    """
+    logger.info("Timeout expired: Game Over!")
+    os.kill(os.getpid(), signal.SIGTERM)
 
 
 def kill_after_delay(timeout_seconds: int) -> None:
@@ -47,10 +48,12 @@ def kill_after_delay(timeout_seconds: int) -> None:
     :param timeout_seconds: The number of seconds to wait before killing the robot
     """
 
-    if IS_LINUX:
-        signal.signal(TERMINATING_SIGNAL, timeout_handler)
-
-    timer = Timer(timeout_seconds, lambda: raise_signal(TERMINATING_SIGNAL))
-
+    if sys.platform == "win32":
+        # Windows doesn't have SIGALRM,
+        # so we approximate its functionality using a delayed SIGTERM
+        timer = Timer(timeout_seconds, win_timeout_handler)
+        timer.start()
+    else:
+        signal.signal(signal.SIGALRM, timeout_handler)
+        signal.alarm(timeout_seconds)
     logger.debug(f"Kill Signal Timeout set: {timeout_seconds}s")
-    timer.start()

--- a/sbot/timeout.py
+++ b/sbot/timeout.py
@@ -1,12 +1,17 @@
 """Functions for killing the robot after a certain amount of time."""
 import logging
 import os
+import platform
 import signal
 from threading import Timer
 from types import FrameType
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+
+IS_LINUX = platform.system() == "Linux"
+TERMINATING_SIGNAL = signal.SIGALRM if IS_LINUX else signal.SIGTERM
 
 
 def raise_signal(signum: int) -> None:
@@ -40,9 +45,10 @@ def kill_after_delay(timeout_seconds: int) -> None:
     :param timeout_seconds: The number of seconds to wait before killing the robot
     """
 
-    signal.signal(signal.SIGTERM, timeout_handler)
+    if IS_LINUX:
+        signal.signal(TERMINATING_SIGNAL, timeout_handler)
 
-    timer = Timer(timeout_seconds, lambda: raise_signal(signal.SIGTERM))
+    timer = Timer(timeout_seconds, lambda: raise_signal(TERMINATING_SIGNAL))
 
     logger.debug(f"Kill Signal Timeout set: {timeout_seconds}s")
     timer.start()

--- a/sbot/timeout.py
+++ b/sbot/timeout.py
@@ -11,7 +11,9 @@ logger = logging.getLogger(__name__)
 
 
 IS_LINUX = platform.system() == "Linux"
-TERMINATING_SIGNAL = signal.SIGALRM if IS_LINUX else signal.SIGTERM
+
+# `SIGALRM` will only exist on Linux
+TERMINATING_SIGNAL = getattr(signal, "SIGALRM", signal.SIGTERM)
 
 
 def raise_signal(signum: int) -> None:

--- a/sbot/timeout.py
+++ b/sbot/timeout.py
@@ -3,19 +3,32 @@ import logging
 import os
 import signal
 from threading import Timer
+from types import FrameType
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-def timeout_handler() -> None:
+def raise_signal(signum: int) -> None:
+    """
+    Sends a signal to the current process.
+
+    Similar to `signal.raise_signal`, however uses the main process's signal handler.
+
+    :param signum: The signal to raise
+    """
+    os.kill(os.getpid(), signum)
+
+
+def timeout_handler(signal_type: int, stack_frame: Optional[FrameType]) -> None:
     """
     Handle the timeout to kill the current process.
 
     This function is called when the timeout expires and will stop the robot's main process.
     In order for this to work, any threads that are created must be daemons.
     """
-    logger.info("Timeout expired: Game Over!")
-    os.kill(os.getpid(), signal.SIGTERM)
+    print("Timeout expired: Game Over!")
+    exit(0)
 
 
 def kill_after_delay(timeout_seconds: int) -> None:
@@ -26,6 +39,10 @@ def kill_after_delay(timeout_seconds: int) -> None:
 
     :param timeout_seconds: The number of seconds to wait before killing the robot
     """
-    timer = Timer(timeout_seconds, timeout_handler)
+
+    signal.signal(signal.SIGTERM, timeout_handler)
+
+    timer = Timer(timeout_seconds, lambda: raise_signal(signal.SIGTERM))
+
     logger.debug(f"Kill Signal Timeout set: {timeout_seconds}s")
     timer.start()

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,7 +1,8 @@
 """Test the timeout function."""
 from time import sleep
 
-import _thread
+import os
+import signal
 
 from sbot.timeout import kill_after_delay
 from unittest.mock import Mock
@@ -9,13 +10,14 @@ from unittest.mock import Mock
 
 def test_kill_after_delay(monkeypatch) -> None:
     """Test that the process is killed within the time."""
-    interrupt_main = Mock()
-    monkeypatch.setattr(_thread, "interrupt_main", interrupt_main)
+    kill = Mock()
+    pid = os.getpid()
+    monkeypatch.setattr(os, "kill", kill)
 
     kill_after_delay(2)
 
     sleep(1)
-    interrupt_main.assert_not_called()
+    kill.assert_not_called()
 
     sleep(1.5)  # Give the kernel a chance.
-    interrupt_main.assert_called_once()
+    kill.assert_called_once_with(pid, signal.SIGTERM)

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,15 +1,21 @@
 """Test the timeout function."""
-import sys
 from time import sleep
 
-import pytest
+import _thread
 
 from sbot.timeout import kill_after_delay
+from unittest.mock import Mock
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_kill_after_delay() -> None:
-    """Test that a SystemExit is raised within the time."""
-    with pytest.raises(SystemExit):
-        kill_after_delay(5)
-        sleep(6)  # Kill within 6 seconds to give the kernel a chance.
+def test_kill_after_delay(monkeypatch) -> None:
+    """Test that the process is killed within the time."""
+    interrupt_main = Mock()
+    monkeypatch.setattr(_thread, "interrupt_main", interrupt_main)
+
+    kill_after_delay(2)
+
+    sleep(1)
+    interrupt_main.assert_not_called()
+
+    sleep(1.5)  # Give the kernel a chance.
+    interrupt_main.assert_called_once()

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -5,35 +5,29 @@ import os
 import signal
 import subprocess
 import sys
+import pytest
+
 
 from sbot.timeout import kill_after_delay
-from unittest.mock import Mock
 
 
 def test_kill_after_delay(monkeypatch) -> None:
     """Test that the process is killed within the time."""
-    kill = Mock()
-    pid = os.getpid()
-    monkeypatch.setattr(os, "kill", kill)
 
-    kill_after_delay(2)
-
-    sleep(1)
-    kill.assert_not_called()
-
-    sleep(1.5)  # Give the kernel a chance.
-    kill.assert_called_once_with(pid, signal.SIGTERM)
+    with pytest.raises(SystemExit):
+        kill_after_delay(2)
+        sleep(3)
 
 
 def test_kill_after_delay_e2e() -> None:
     child = subprocess.Popen([
         sys.executable,
         "-c",
-        'from sbot.timeout import kill_after_delay; import time; kill_after_delay(2); time.sleep(10)'
-    ])
+        'from sbot.timeout import kill_after_delay; import time; kill_after_delay(2); time.sleep(10)',
+    ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     sleep(1)
     assert child.poll() is None
 
     sleep(2)
-    assert abs(child.poll()) == signal.SIGTERM
+    assert child.poll() == 0

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -3,6 +3,8 @@ from time import sleep
 
 import os
 import signal
+import subprocess
+import sys
 
 from sbot.timeout import kill_after_delay
 from unittest.mock import Mock
@@ -21,3 +23,17 @@ def test_kill_after_delay(monkeypatch) -> None:
 
     sleep(1.5)  # Give the kernel a chance.
     kill.assert_called_once_with(pid, signal.SIGTERM)
+
+
+def test_kill_after_delay_e2e() -> None:
+    child = subprocess.Popen([
+        sys.executable,
+        "-c",
+        'from sbot.timeout import kill_after_delay; import time; kill_after_delay(2); time.sleep(10)'
+    ])
+
+    sleep(1)
+    assert child.poll() is None
+
+    sleep(2)
+    assert abs(child.poll()) == signal.SIGTERM

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,5 +1,5 @@
 """Test the timeout function."""
-from time import sleep
+from time import sleep, time
 
 import os
 import signal
@@ -20,14 +20,19 @@ def test_kill_after_delay(monkeypatch) -> None:
 
 
 def test_kill_after_delay_e2e() -> None:
+    start_time = time()
     child = subprocess.Popen([
         sys.executable,
         "-c",
         'from sbot.timeout import kill_after_delay; import time; kill_after_delay(2); time.sleep(10)',
     ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-    sleep(1)
-    assert child.poll() is None
+    child.wait(timeout=5)
 
-    sleep(2)
-    assert child.poll() == 0
+    assert time() - start_time == pytest.approx(2, rel=1)
+
+    if sys.platform == "win32":
+        # Windows terminates uncleanly
+        assert child.returncode == signal.SIGTERM
+    else:
+        assert child.returncode == 0


### PR DESCRIPTION
This means the implementation is cross-platform. Because it's a thread timer, it shouldn't have the same issues as `time.sleep`.

See also https://github.com/sourcebots/robot-api/pull/100/.