### PR TITLE
Rename constructor arg "wait_for_start"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ r = Robot()
 
 ```
 
-To disable the waiting for the start button, you can pass `wait_start=False` to the constructor.
-The `wait_start` method needs to be called before the metadata is available.
+To disable the waiting for the start button, you can pass `wait_for_start=False` to the constructor.
+The `wait_for_start` method needs to be called before the metadata is available.
 
 ```python
 
 from sbot import Robot
 
-r = Robot(wait_start=False)
+r = Robot(wait_for_start=False)
 
 # Setup in here
 

--- a/sbot/robot.py
+++ b/sbot/robot.py
@@ -30,7 +30,7 @@ class Robot:
     system at a time, creating a second instance will raise an OSError.
 
     :param debug: Enable debug logging to the console, defaults to False
-    :param wait_start: Wait in the constructor until the start button is pressed,
+    :param wait_for_start: Wait in the constructor until the start button is pressed,
         defaults to True
     :param trace_logging: Enable trace level logging to the console, defaults to False
     :param manual_boards: A dictionary of board types to a list of serial port paths
@@ -45,7 +45,7 @@ class Robot:
         self,
         *,
         debug: bool = False,
-        wait_start: bool = True,
+        wait_for_start: bool = True,
         trace_logging: bool = False,
         manual_boards: dict[str, list[str]] | None = None,
     ) -> None:
@@ -65,7 +65,7 @@ class Robot:
         self._init_camera()
         self._log_connected_boards()
 
-        if wait_start:
+        if wait_for_start:
             self.wait_start()
 
     def _init_power_board(self, manual_boards: list[str] | None = None) -> None:

--- a/tests/test_sbot.py
+++ b/tests/test_sbot.py
@@ -77,7 +77,7 @@ def test_robot(monkeypatch, caplog) -> None:
     lock.close()  # release the lock
 
     # Test that we can create a robot object
-    r = Robot(wait_start=False, manual_boards=manual_boards, debug=True)
+    r = Robot(wait_for_start=False, manual_boards=manual_boards, debug=True)
     assert caplog.record_tuples[1:] == [
         # First line contains the version number
         ('sbot.robot', logging.INFO, 'Found PowerBoard, serial: POW123'),
@@ -127,7 +127,7 @@ def test_robot(monkeypatch, caplog) -> None:
 def test_robot_discovery() -> None:
     """Test that we can discover all the boards when creating a Robot object."""
     from sbot import Robot
-    robot = Robot(wait_start=False)
+    robot = Robot(wait_for_start=False)
 
     # Test that we can access the singular boards
     power_asset_tag = robot.power_board.identify().asset_tag


### PR DESCRIPTION
This is clearer what passing the value is doing.

Note I've not changed `robot.wait_start()`, as IMO that's clear what it's doing, as it's an imperative action.