### PR TITLE
Ensure `atexit` runs on `SIGTERM`

### DIFF
--- a/sbot/robot.py
+++ b/sbot/robot.py
@@ -17,7 +17,7 @@ from .metadata import Metadata
 from .motor_board import MotorBoard
 from .power_board import Note, PowerBoard
 from .servo_board import ServoBoard
-from .utils import obtain_lock, singular
+from .utils import ensure_atexit_on_term, obtain_lock, singular
 
 try:
     from .mqtt import MQTT_VALID, MQTTClient, get_mqtt_variables
@@ -58,6 +58,7 @@ class Robot:
         self._metadata: Metadata | None = None
 
         setup_logging(debug, trace_logging)
+        ensure_atexit_on_term()
 
         logger.info(f"SourceBots API v{__version__}")
 

--- a/sbot/utils.py
+++ b/sbot/utils.py
@@ -6,7 +6,7 @@ import signal
 import socket
 from abc import ABC, abstractmethod
 from types import FrameType
-from typing import Any, Mapping, NamedTuple, Optional, TypeVar
+from typing import Any, Mapping, NamedTuple, TypeVar
 
 from serial.tools.list_ports_common import ListPortInfo
 
@@ -216,7 +216,7 @@ def ensure_atexit_on_term() -> None:
         # this is sufficient for `atexit` to trigger, so do nothing.
         return
 
-    def handle_signal(handled_signum: int, frame: Optional[FrameType]) -> None:
+    def handle_signal(handled_signum: int, frame: FrameType | None) -> None:
         """
         Handle the given signal by outputting some text and terminating the process.
 

--- a/sbot/utils.py
+++ b/sbot/utils.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import logging
+import signal
 import socket
 from abc import ABC, abstractmethod
-from typing import Any, Mapping, NamedTuple, TypeVar
+from types import FrameType
+from typing import Any, Mapping, NamedTuple, Optional, TypeVar
 
 from serial.tools.list_ports_common import ListPortInfo
 
@@ -199,3 +201,29 @@ def get_USB_identity(port: ListPortInfo) -> BoardIdentity:
         logger.warning(
             f"Failed to pull identifying information from serial device {port.device}")
         return BoardIdentity()
+
+
+def ensure_atexit_on_term() -> None:
+    """
+    Ensure `atexit` triggers on `SIGTERM`.
+
+    > The functions registered via [`atexit`] are not called when the program is
+      killed by a signal not handled by Python
+    """
+
+    if signal.getsignal(signal.SIGTERM) != signal.SIG_DFL:
+        # If a signal handler is already present for SIGTERM,
+        # this is sufficient for `atexit` to trigger, so do nothing.
+        return
+
+    def handle_signal(handled_signum: int, frame: Optional[FrameType]) -> None:
+        """
+        Handle the given signal by outputting some text and terminating the process.
+
+        This will trigger `atexit`.
+        """
+        logger.info(signal.strsignal(handled_signum))
+        exit(1)
+
+    # Add the null-ish signal handler
+    signal.signal(signal.SIGTERM, handle_signal)

--- a/tests/test_sbot.py
+++ b/tests/test_sbot.py
@@ -3,6 +3,7 @@ import logging
 import socket
 
 import pytest
+import signal
 
 from sbot import Robot
 from sbot.exceptions import MetadataNotReadyError
@@ -120,6 +121,9 @@ def test_robot(monkeypatch, caplog) -> None:
     r.wait_start()
 
     assert r.zone == 0
+
+    # Check _something_ is configured to handle SIGTERM
+    assert signal.getsignal(signal.SIGTERM) != signal.SIG_DFL
 
 
 @pytest.hookimpl(trylast=True)


### PR DESCRIPTION
It requires a signal handler to run, so we add a blank one (if there isn't one already)

See the "Note: " at the top of https://docs.python.org/3/library/atexit.html for details as to why this is necessary.