### PR TITLE
Update servo limits, numbers and defaults for servo fw 4.4

### DIFF
--- a/sbot/servo_board.py
+++ b/sbot/servo_board.py
@@ -16,10 +16,11 @@ from .utils import (
     get_USB_identity, map_to_float, map_to_int,
 )
 
-DUTY_MIN = 500
+DUTY_MIN = 300
 DUTY_MAX = 4000
-START_DUTY_MIN = 1000
-START_DUTY_MAX = 2000
+START_DUTY_MIN = 350
+START_DUTY_MAX = 1980
+NUM_SERVOS = 8
 
 logger = logging.getLogger(__name__)
 BAUDRATE = 115200  # Since the servo board is a USB device, this is ignored
@@ -77,7 +78,7 @@ class ServoBoard(Board):
         self._serial = SerialWrapper(serial_port, BAUDRATE, identity=initial_identity)
 
         self._servos = tuple(
-            Servo(self._serial, index) for index in range(12)
+            Servo(self._serial, index) for index in range(NUM_SERVOS)
         )
 
         self._identity = self.identify()


### PR DESCRIPTION
With [servo firmware 4.4](https://github.com/srobo/servo-v4-fw/releases/tag/4.4) the servo board can produce the full range of motion with SRO's servos. 

The only limitation is that only 8 servos can be controlled so the auxiliary servo ports are unusable. (I have a 3d-printed plug for that port.)

This updates the servo API to recognise these new limits and sets the default range to that of the SRO servos.