### PR TITLE
Set the write timeout for the serial port

### DIFF
--- a/sbot/serial_wrapper.py
+++ b/sbot/serial_wrapper.py
@@ -96,6 +96,7 @@ class SerialWrapper:
             port,
             baudrate=baud,
             timeout=timeout,
+            write_timeout=timeout,
             do_not_open=True,
         )
 


### PR DESCRIPTION
Without this, the write can block indefinitely with USB serial ports if the remote device doesn't service the port.
This can occur with Arduinos when large volumnes of data are being sent by the Arduino