### PR TITLE
Update power port for KCH usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ Documentation = "https://docs.sourcebots.co.uk"
 dev = [
     "flake8",
     "isort",
-    "mypy",
+    "mypy==1.10.0; python_version<'3.9'",
+    "mypy; python_version>='3.9'",
     "build",
     "types-pyserial",
     "pytest",

--- a/sbot/power_board.py
+++ b/sbot/power_board.py
@@ -61,7 +61,7 @@ class PowerStatus(NamedTuple):
 
 
 # This output is always on, and cannot be controlled via the API.
-BRAIN_OUTPUT = PowerOutputPosition.FIVE_VOLT
+BRAIN_OUTPUT = PowerOutputPosition.L2
 
 
 class PowerBoard(Board):

--- a/tests/test_power_board.py
+++ b/tests/test_power_board.py
@@ -195,7 +195,7 @@ def test_power_board_outputs(powerboard_serial: MockPowerBoard) -> None:
     power_board.outputs[PowerOutputPosition.FIVE_VOLT].is_enabled = True
     power_board.outputs[PowerOutputPosition.FIVE_VOLT].is_enabled = False
 
-    # Test that we can't enable or disable the 5V output
+    # Test that we can't enable or disable the brain output
     with pytest.raises(RuntimeError, match=r"Brain output cannot be controlled.*"):
         power_board.outputs[PowerOutputPosition.L2].is_enabled = True
 

--- a/tests/test_power_board.py
+++ b/tests/test_power_board.py
@@ -155,14 +155,14 @@ def test_power_board_outputs(powerboard_serial: MockPowerBoard) -> None:
         ("OUT:1:SET:1", "ACK"),
         ("OUT:2:SET:1", "ACK"),
         ("OUT:3:SET:1", "ACK"),
-        ("OUT:4:SET:1", "ACK"),
         ("OUT:5:SET:1", "ACK"),
+        ("OUT:6:SET:1", "ACK"),
         ("OUT:0:SET:0", "ACK"),
         ("OUT:1:SET:0", "ACK"),
         ("OUT:2:SET:0", "ACK"),
         ("OUT:3:SET:0", "ACK"),
-        ("OUT:4:SET:0", "ACK"),
         ("OUT:5:SET:0", "ACK"),
+        ("OUT:6:SET:0", "ACK"),
     ])
     power_board.outputs.power_on()
     power_board.outputs.power_off()
@@ -177,10 +177,10 @@ def test_power_board_outputs(powerboard_serial: MockPowerBoard) -> None:
         ("OUT:2:SET:0", "ACK"),
         ("OUT:3:SET:1", "ACK"),
         ("OUT:3:SET:0", "ACK"),
-        ("OUT:4:SET:1", "ACK"),
-        ("OUT:4:SET:0", "ACK"),
         ("OUT:5:SET:1", "ACK"),
         ("OUT:5:SET:0", "ACK"),
+        ("OUT:6:SET:1", "ACK"),
+        ("OUT:6:SET:0", "ACK"),
     ])
     power_board.outputs[PowerOutputPosition.H0].is_enabled = True
     power_board.outputs[PowerOutputPosition.H0].is_enabled = False
@@ -190,14 +190,14 @@ def test_power_board_outputs(powerboard_serial: MockPowerBoard) -> None:
     power_board.outputs[PowerOutputPosition.L0].is_enabled = False
     power_board.outputs[PowerOutputPosition.L1].is_enabled = True
     power_board.outputs[PowerOutputPosition.L1].is_enabled = False
-    power_board.outputs[PowerOutputPosition.L2].is_enabled = True
-    power_board.outputs[PowerOutputPosition.L2].is_enabled = False
     power_board.outputs[PowerOutputPosition.L3].is_enabled = True
     power_board.outputs[PowerOutputPosition.L3].is_enabled = False
+    power_board.outputs[PowerOutputPosition.FIVE_VOLT].is_enabled = True
+    power_board.outputs[PowerOutputPosition.FIVE_VOLT].is_enabled = False
 
     # Test that we can't enable or disable the 5V output
     with pytest.raises(RuntimeError, match=r"Brain output cannot be controlled.*"):
-        power_board.outputs[PowerOutputPosition.FIVE_VOLT].is_enabled = True
+        power_board.outputs[PowerOutputPosition.L2].is_enabled = True
 
     # Test that we can detect whether the power board outputs are enabled
     powerboard_serial.serial_wrapper._add_responses([

--- a/tests/test_sbot.py
+++ b/tests/test_sbot.py
@@ -22,8 +22,8 @@ def test_robot(monkeypatch, caplog) -> None:
         ("OUT:1:SET:1", "ACK"),
         ("OUT:2:SET:1", "ACK"),
         ("OUT:3:SET:1", "ACK"),
-        ("OUT:4:SET:1", "ACK"),
         ("OUT:5:SET:1", "ACK"),
+        ("OUT:6:SET:1", "ACK"),
         ("*IDN?", "Student Robotics:PBv4B:POW123:4.4.1"),
         ("BTN:START:GET?", "0:1"),
         ("NOTE:1760:100", "ACK"),  # Start up sound


### PR DESCRIPTION
The KCH is powered by 12V so the automatically enabled port needs to be L2 instead of the 5 volt output.

Note: once this is included power boards will need to be updated to the 4.4.2 firmware instead of 4.4.2-sb