### PR TITLE
Prevent negative indexing

### DIFF
--- a/sbot/internal/board_manager.py
+++ b/sbot/internal/board_manager.py
@@ -416,6 +416,7 @@ class BoardManager:
         :raises ValueError: If the output does not exist on the board.
         :raises KeyError: If no board with the given identifier is registered.
         """
+        assert idx >= 0, "Output identifiers must be positive"
         try:
             return self.outputs[identifier][idx]
         except IndexError:


### PR DESCRIPTION
Assert if teams attempt to use indexes such as -1 when accessing motors, etc.

This may occur if the arguments are in the inccorrect order while setting a motor to rotate backward.